### PR TITLE
US132657 - trim whitespace for ignore list searches

### DIFF
--- a/src/components/module-scheduler-ignore-list.js
+++ b/src/components/module-scheduler-ignore-list.js
@@ -240,7 +240,7 @@ class ModuleSchedulerIgnoreList extends BaseMixin(LocalizeMixin(LitElement)) {
 	}
 
 	_handleSearch(e) {
-		this._searchText = e.detail.value;
+		this._searchText = e.detail.value.trim();
 		this._pageNumber = 1;
 	}
 


### PR DESCRIPTION
For consistency with other searches in the LMS e.g. [course copy activity](https://github.com/Brightspace/copy-assignment-to-other-courses/blob/master/src/components/catoc-course-selection.js#L309), trim whitespace from the start & end of the search string.

Rally:  [US132657](https://rally1.rallydev.com/#/?detail=/userstory/610991032451&fdp=true): [AAU] Module Schedule Tool - Ignore List - Pagination & Search